### PR TITLE
Add IDR if bitrate change.

### DIFF
--- a/omx_utils/src/mfx_omx_structures.cpp
+++ b/omx_utils/src/mfx_omx_structures.cpp
@@ -1169,6 +1169,16 @@ OMX_ERRORTYPE omx2mfx_config(
     config.mfxparams->mfx.TargetKbps = (mfxU16)(omxparams.nEncodeBitrate * 0.001);
     config.mfxparams->mfx.MaxKbps = 0;
 
+    if (config.bCodecInitialized && (MFX_CODEC_HEVC == config.mfxparams->mfx.CodecId))
+    {
+        int idx;
+        idx = config.mfxparams->enableExtParam(MFX_EXTBUFF_ENCODER_RESET_OPTION);
+        if (idx < 0 || idx >= MFX_OMX_ENCODE_VIDEOPARAM_EXTBUF_MAX_NUM)
+            return OMX_ErrorInsufficientResources;
+        else
+            config.mfxparams->ext_buf[idx].reset.StartNewSequence = MFX_CODINGOPTION_ON;
+    }
+
     return OMX_ErrorNone;
 }
 


### PR DESCRIPTION
For HEVC encode if bitrate changed then an IDR should be
added.

Tracked-On: OAM-95402
Signed-off-by: Yang, Dong <dong.yang@intel.com>