### PR TITLE
Add color aspect info for video encoder

### DIFF
--- a/omx_components/include/mfx_omx_venc_component.h
+++ b/omx_components/include/mfx_omx_venc_component.h
@@ -26,6 +26,7 @@
 #include "mfx_omx_srf_ibuf.h"
 #include "mfx_omx_bst_pool.h"
 #include "mfx_omx_dev.h"
+#include "mfx_omx_color_aspects_wrapper.h"
 
 /*------------------------------------------------------------------------------*/
 
@@ -201,6 +202,8 @@ protected:
 
     mfxU32 m_nEncoderInputSurfacesCount;
     mfxU32 m_nEncoderOutputBitstreamsCount;
+
+    MfxOmxColorAspectsWrapper m_colorAspects;
 
     buffer_handle_t m_blackFrame;
 

--- a/omx_components/src/mfx_omx_ports.cpp
+++ b/omx_components/src/mfx_omx_ports.cpp
@@ -130,6 +130,7 @@ bool mfx_omx_is_index_valid(OMX_INDEXTYPE index, MfxOmxPortId port_id)
             if (MfxOmx_IndexIntelIdrInterval == index) return true;
             if (MfxOmx_IndexIntelGopRefDist == index) return true;
             if (MfxOmx_IndexIntelLowPower == index) return true;
+            if (MfxOmx_IndexGoogleDescribeColorAspects == index) return true;
             break;
         case MfxOmxPortVideo_h264vd:
             if (OMX_IndexParamVideoProfileLevelQuerySupported == index) return true;
@@ -161,6 +162,7 @@ bool mfx_omx_is_index_valid(OMX_INDEXTYPE index, MfxOmxPortId port_id)
             if (MfxOmx_IndexIntelIdrInterval == index) return true;
             if (MfxOmx_IndexIntelGopRefDist == index) return true;
             if (MfxOmx_IndexIntelDisableDeblockingIdc == index) return true;
+            if (MfxOmx_IndexGoogleDescribeColorAspects == index) return true;
             break;
         case MfxOmxPortVideo_vp9ve:
             if (OMX_IndexParamVideoVp9 == index) return true;

--- a/omx_components/src/mfx_omx_vdec_component.cpp
+++ b/omx_components/src/mfx_omx_vdec_component.cpp
@@ -330,6 +330,9 @@ void MfxOmxVdecComponent::Reset(void)
         MFX_OMX_AUTO_TRACE_MSG("Unhandled codec type: error in plug-in registration");
         break;
     }
+
+    m_colorAspects.SetCodecID(m_MfxVideoParams.mfx.CodecId);
+
     mfx_omx_set_defaults_mfxVideoParam_dec(&m_MfxVideoParams);
 
     PortsParams_2_MfxVideoParams();
@@ -2441,7 +2444,7 @@ mfxStatus MfxOmxVdecComponent::InitCodec(void)
                     MFX_OMX_LOG_INFO_IF(g_OmxLogLevel, "Requesting change of output port settings");
                     m_pCallbacks->EventHandler(m_self, m_pAppData, OMX_EventPortSettingsChanged, MFX_OMX_OUTPUT_PORT_INDEX, OMX_IndexParamPortDefinition, NULL);
                 }
-                else if (m_colorAspects.IsColorAspectsCnahged())
+                else if (m_colorAspects.IsColorAspectsChanged())
                 {
                     MFX_OMX_AUTO_TRACE_MSG("Color aspects parsed from bitsream is defferent than passed from framework");
                     MFX_OMX_LOG_INFO_IF(g_OmxLogLevel, "Color aspects parsed from bitsream is defferent than passed from framework");
@@ -2700,7 +2703,7 @@ mfxStatus MfxOmxVdecComponent::ReinitCodec(void)
         }
     }
 
-    if (!bIsEventWasSent && m_colorAspects.IsColorAspectsCnahged())
+    if (!bIsEventWasSent && m_colorAspects.IsColorAspectsChanged())
     {
         MFX_OMX_AUTO_TRACE_MSG("Color aspects parsed from bitsream is defferent than passed from framework");
         MFX_OMX_LOG_INFO_IF(g_OmxLogLevel, "Color aspects parsed from bitsream is defferent than passed from framework");

--- a/omx_utils/include/mfx_omx_color_aspects_wrapper.h
+++ b/omx_utils/include/mfx_omx_color_aspects_wrapper.h
@@ -33,25 +33,39 @@ public:
     void SetFrameworkColorAspects(const android::ColorAspects &colorAspects);
     void UpdateBitsreamColorAspects(const mfxExtVideoSignalInfo &signalInfo);
     void GetOutputColorAspects(android::ColorAspects &outColorAspects);
+    void GetColorAspectsFromVideoSignal(const mfxExtVideoSignalInfo &signalInfo, android::ColorAspects &outColorAspects);
+    void ConvertFrameworkColorAspectToCodecColorAspect(const android::ColorAspects &colorAspects, OMX_VIDEO_PARAM_COLOR_ASPECT &colorParams);
 
-    bool IsColorAspectsCnahged();
+    bool IsColorAspectsChanged();
     void SignalChangedColorAspectsIsSent();
 
-private:
+    void SetCodecID(mfxU32 codecId);
 
-    void MfxToOmxVideoRange(mfxU16 videoRange);
-    void MfxToOmxColourPrimaries(mfxU16 colourPrimaries);
-    void MfxToOmxTransferCharacteristics(mfxU16 transferCharacteristics);
-    void MfxToOmxMatrixCoefficients(mfxU16 MatrixCoefficients);
+private:
+    // mfx to omx
+    // converters VideoSignalInfo from MFX to OMX API
+    void MfxToOmxVideoRange(mfxU16 videoRange, android::ColorAspects::Range &out);
+    void MfxToOmxColourPrimaries(mfxU16 colourPrimaries, android::ColorAspects::Primaries &out);
+    void MfxToOmxTransferCharacteristics(mfxU16 transferCharacteristics, android::ColorAspects::Transfer &out);
+    void MfxToOmxMatrixCoefficients(mfxU16 MatrixCoefficients, android::ColorAspects::MatrixCoeffs &out);
+
+    // omx to mfx
+    // converters VideoSignalInfo from OMX API to MFX
+    void OmxToMfxVideoRange(android::ColorAspects::Range videoRange, mfxU16 &out);
+    void OmxToMfxColourPrimaries(android::ColorAspects::Primaries colourPrimaries, mfxU16 &out);
+    void OmxToMfxTransferCharacteristics(android::ColorAspects::Transfer transferCharacteristics, mfxU16 &out);
+    void OmxToMfxMatrixCoefficients(android::ColorAspects::MatrixCoeffs matrixCoefficients, mfxU16 &out);
 
 private:
 
     // Color aspects passed from the framework.
     android::ColorAspects m_frameworkColorAspects;
-    // Color aspects parsed from the bitstream.
+    // Color aspects parsed from the bitstream. For decoder use only.
     android::ColorAspects m_bitstreamColorAspects;
 
     bool m_bIsColorAspectsChanged;
+
+    mfxU32 m_codecId;
 
     MFX_OMX_CLASS_NO_COPY(MfxOmxColorAspectsWrapper)
 };

--- a/omx_utils/include/mfx_omx_defs.h
+++ b/omx_utils/include/mfx_omx_defs.h
@@ -411,6 +411,16 @@ const char* mfx_omx_code_to_string(mfxStatus sts);
 
 /*------------------------------------------------------------------------------*/
 
+#define MFX_OMX_AT__OMX_VIDEO_CONFIG_COLORASPECT(_coloraspect) \
+    MFX_OMX_AT__OMX_STRUCT(_coloraspect); \
+    MFX_OMX_AUTO_TRACE_I32(_coloraspect.nPortIndex); \
+    MFX_OMX_AUTO_TRACE_I32(_coloraspect.nColourPrimaries); \
+    MFX_OMX_AUTO_TRACE_I32(_coloraspect.nVideoFullRange); \
+    MFX_OMX_AUTO_TRACE_I32(_coloraspect.nMatrixCoefficients); \
+    MFX_OMX_AUTO_TRACE_I32(_coloraspect.nTransferCharacteristics);
+
+/********************************************************************************/
+
 #define MFX_OMX_AT__OMX_VIDEO_CONFIG_INTEL_BITRATETYPE(_config_intel_bitrate_type) \
     MFX_OMX_AT__OMX_STRUCT(_config_intel_bitrate_type); \
     MFX_OMX_AUTO_TRACE_I32(_config_intel_bitrate_type.nPortIndex); \
@@ -903,6 +913,16 @@ const char* mfx_omx_code_to_string(mfxStatus sts);
 
 /*------------------------------------------------------------------------------*/
 
+#define MFX_OMX_AT__mfxExtVideoSignalInfo(_opt) \
+    MFX_OMX_AUTO_TRACE_I32(_opt.VideoFormat); \
+    MFX_OMX_AUTO_TRACE_I32(_opt.VideoFullRange); \
+    MFX_OMX_AUTO_TRACE_I32(_opt.ColourDescriptionPresent); \
+    MFX_OMX_AUTO_TRACE_I32(_opt.ColourPrimaries); \
+    MFX_OMX_AUTO_TRACE_I32(_opt.TransferCharacteristics); \
+    MFX_OMX_AUTO_TRACE_I32(_opt.MatrixCoefficients);
+
+/*------------------------------------------------------------------------------*/
+
 #define MFX_OMX_AT__mfxExtParams(_num, _params) \
     if(_params) \
     { \
@@ -926,6 +946,9 @@ const char* mfx_omx_code_to_string(mfxStatus sts);
                 break; \
               case MFX_EXTBUFF_AVC_TEMPORAL_LAYERS: \
                 MFX_OMX_AT__mfxExtEncoderTemporalLayersOption((*((mfxExtAvcTemporalLayers*)_params[i]))); \
+                break; \
+              case MFX_EXTBUFF_VIDEO_SIGNAL_INFO: \
+                MFX_OMX_AT__mfxExtVideoSignalInfo((*((mfxExtVideoSignalInfo*)_params[i]))); \
                 break; \
               default: \
                 MFX_OMX_AUTO_TRACE_MSG("unknown ext buffer"); \

--- a/omx_utils/src/mfx_omx_color_aspects_wrapper.cpp
+++ b/omx_utils/src/mfx_omx_color_aspects_wrapper.cpp
@@ -25,6 +25,8 @@ MfxOmxColorAspectsWrapper::MfxOmxColorAspectsWrapper()
 {
     MFX_OMX_AUTO_TRACE_FUNC();
 
+    m_codecId = MFX_CODEC_AVC;
+
     // Init all the color aspects to be Unspecified.
     memset(&m_frameworkColorAspects, 0, sizeof(android::ColorAspects));
     memset(&m_bitstreamColorAspects, 0, sizeof(android::ColorAspects));
@@ -33,6 +35,14 @@ MfxOmxColorAspectsWrapper::MfxOmxColorAspectsWrapper()
 MfxOmxColorAspectsWrapper::~MfxOmxColorAspectsWrapper()
 {
     MFX_OMX_AUTO_TRACE_FUNC();
+}
+
+void MfxOmxColorAspectsWrapper::SetCodecID(mfxU32 codecId)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+	m_codecId = codecId;
+	MFX_OMX_AUTO_TRACE_I32(m_codecId);
 }
 
 void MfxOmxColorAspectsWrapper::SetFrameworkColorAspects(const android::ColorAspects &colorAspects)
@@ -56,10 +66,27 @@ void MfxOmxColorAspectsWrapper::UpdateBitsreamColorAspects(const mfxExtVideoSign
     MFX_OMX_AUTO_TRACE_I32(signalInfo.TransferCharacteristics);
     MFX_OMX_AUTO_TRACE_I32(signalInfo.MatrixCoefficients);
 
-    MfxToOmxVideoRange(signalInfo.VideoFullRange);
-    MfxToOmxColourPrimaries(signalInfo.ColourPrimaries);
-    MfxToOmxTransferCharacteristics(signalInfo.TransferCharacteristics);
-    MfxToOmxMatrixCoefficients(signalInfo.MatrixCoefficients);
+    MfxToOmxVideoRange(signalInfo.VideoFullRange, m_bitstreamColorAspects.mRange);
+    MfxToOmxColourPrimaries(signalInfo.ColourPrimaries, m_bitstreamColorAspects.mPrimaries);
+    MfxToOmxTransferCharacteristics(signalInfo.TransferCharacteristics, m_bitstreamColorAspects.mTransfer);
+    MfxToOmxMatrixCoefficients(signalInfo.MatrixCoefficients, m_bitstreamColorAspects.mMatrixCoeffs);
+
+    mfxU16 video_signal_type_present_flag = signalInfo.VideoFormat != 5 ||
+		                                    signalInfo.VideoFullRange != 0 ||
+					                        signalInfo.ColourDescriptionPresent != 0;
+
+	if (MFX_CODEC_VP9 == m_codecId || MFX_CODEC_VP8 == m_codecId)
+	{
+	    video_signal_type_present_flag = false;
+	}
+
+	if (!video_signal_type_present_flag)
+	{
+	    m_bitstreamColorAspects.mRange = android::ColorAspects::RangeUnspecified;
+        m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesUnspecified;
+        m_bitstreamColorAspects.mTransfer  = android::ColorAspects::TransferUnspecified;
+        m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixUnspecified;
+	}
 
     if ((m_bitstreamColorAspects.mRange        != android::ColorAspects::RangeUnspecified &&
          m_bitstreamColorAspects.mRange        != m_frameworkColorAspects.mRange)     ||
@@ -114,7 +141,55 @@ void MfxOmxColorAspectsWrapper::GetOutputColorAspects(android::ColorAspects &out
     MFX_OMX_AUTO_TRACE_I32(outColorAspects.mMatrixCoeffs);
 }
 
-bool MfxOmxColorAspectsWrapper::IsColorAspectsCnahged()
+void MfxOmxColorAspectsWrapper::GetColorAspectsFromVideoSignal(const mfxExtVideoSignalInfo &signalInfo, android::ColorAspects &outColorAspects)
+{
+    bool video_signal_type_present_flag = signalInfo.VideoFormat != 5 ||
+                                            signalInfo.VideoFullRange != 0 ||
+					                        signalInfo.ColourDescriptionPresent != 0;
+
+	if (MFX_CODEC_VP9 == m_codecId || MFX_CODEC_VP8 == m_codecId)
+	{
+	    // No video signal info present in vpx bitstream.
+	    video_signal_type_present_flag = false;
+	}
+
+	if (video_signal_type_present_flag)
+	{
+		MfxToOmxColourPrimaries(signalInfo.ColourPrimaries, outColorAspects.mPrimaries);
+        MfxToOmxVideoRange(signalInfo.VideoFullRange, outColorAspects.mRange);
+        MfxToOmxTransferCharacteristics(signalInfo.TransferCharacteristics, outColorAspects.mTransfer);
+        MfxToOmxMatrixCoefficients(signalInfo.MatrixCoefficients, outColorAspects.mMatrixCoeffs);
+	}
+	else
+	{
+        outColorAspects.mPrimaries = android::ColorAspects::PrimariesUnspecified;
+        outColorAspects.mRange = android::ColorAspects::RangeUnspecified;
+        outColorAspects.mTransfer = android::ColorAspects::TransferUnspecified;
+        outColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixUnspecified;
+    }
+
+    MFX_OMX_AUTO_TRACE_I32(outColorAspects.mRange);
+    MFX_OMX_AUTO_TRACE_I32(outColorAspects.mPrimaries);
+    MFX_OMX_AUTO_TRACE_I32(outColorAspects.mTransfer);
+    MFX_OMX_AUTO_TRACE_I32(outColorAspects.mMatrixCoeffs);
+}
+
+void MfxOmxColorAspectsWrapper::ConvertFrameworkColorAspectToCodecColorAspect(const android::ColorAspects &colorAspects, OMX_VIDEO_PARAM_COLOR_ASPECT &colorParams)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+    OmxToMfxColourPrimaries(colorAspects.mPrimaries, colorParams.nColourPrimaries);
+	OmxToMfxVideoRange(colorAspects.mRange, colorParams.nVideoFullRange);
+	OmxToMfxTransferCharacteristics(colorAspects.mTransfer, colorParams.nTransferCharacteristics);
+	OmxToMfxMatrixCoefficients(colorAspects.mMatrixCoeffs, colorParams.nMatrixCoefficients);
+
+    MFX_OMX_AUTO_TRACE_I32(colorParams.nColourPrimaries);
+    MFX_OMX_AUTO_TRACE_I32(colorParams.nVideoFullRange);
+    MFX_OMX_AUTO_TRACE_I32(colorParams.nTransferCharacteristics);
+    MFX_OMX_AUTO_TRACE_I32(colorParams.nMatrixCoefficients);
+}
+
+bool MfxOmxColorAspectsWrapper::IsColorAspectsChanged()
 {
     MFX_OMX_AUTO_TRACE_FUNC();
     MFX_OMX_AUTO_TRACE_I32(m_bIsColorAspectsChanged);
@@ -129,10 +204,7 @@ void MfxOmxColorAspectsWrapper::SignalChangedColorAspectsIsSent()
     m_bIsColorAspectsChanged = false;
 }
 
-
-// Private methods - converters VideoSignalInfo from MFX to OMX API
-
-void MfxOmxColorAspectsWrapper::MfxToOmxVideoRange(mfxU16 videoRange)
+void MfxOmxColorAspectsWrapper::MfxToOmxVideoRange(mfxU16 videoRange, android::ColorAspects::Range &out)
 {
     MFX_OMX_AUTO_TRACE_FUNC();
     MFX_OMX_AUTO_TRACE_I32(videoRange);
@@ -140,22 +212,22 @@ void MfxOmxColorAspectsWrapper::MfxToOmxVideoRange(mfxU16 videoRange)
     switch (videoRange)
     {
         case 0:
-            m_bitstreamColorAspects.mRange = android::ColorAspects::RangeLimited;
+            out = android::ColorAspects::RangeLimited;
             break;
 
         case 1:
-            m_bitstreamColorAspects.mRange = android::ColorAspects::RangeFull;
+            out = android::ColorAspects::RangeFull;
             break;
 
         default:
-            m_bitstreamColorAspects.mRange = android::ColorAspects::RangeUnspecified;
+            out = android::ColorAspects::RangeUnspecified;
             break;
     }
 
-    MFX_OMX_AUTO_TRACE_I32(m_bitstreamColorAspects.mRange);
+    MFX_OMX_AUTO_TRACE_I32(out);
 }
 
-void MfxOmxColorAspectsWrapper::MfxToOmxColourPrimaries(mfxU16 colourPrimaries)
+void MfxOmxColorAspectsWrapper::MfxToOmxColourPrimaries(mfxU16 colourPrimaries, android::ColorAspects::Primaries &out)
 {
     MFX_OMX_AUTO_TRACE_FUNC();
     MFX_OMX_AUTO_TRACE_I32(colourPrimaries);
@@ -163,42 +235,42 @@ void MfxOmxColorAspectsWrapper::MfxToOmxColourPrimaries(mfxU16 colourPrimaries)
     switch (colourPrimaries)
     {
         case 1:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesBT709_5;
+            out = android::ColorAspects::PrimariesBT709_5;
             break;
 
         case 2:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesUnspecified;
+            out = android::ColorAspects::PrimariesUnspecified;
             break;
 
         case 4:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesBT470_6M;
+            out = android::ColorAspects::PrimariesBT470_6M;
             break;
 
         case 5:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesBT601_6_625;
+            out = android::ColorAspects::PrimariesBT601_6_625;
             break;
 
         case 6:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesBT601_6_525;
+            out = android::ColorAspects::PrimariesBT601_6_525;
             break;
 
         case 8:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesGenericFilm;
+            out = android::ColorAspects::PrimariesGenericFilm;
             break;
 
         case 9:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesBT2020;
+            out = android::ColorAspects::PrimariesBT2020;
             break;
 
         default:
-            m_bitstreamColorAspects.mPrimaries = android::ColorAspects::PrimariesUnspecified;
+            out = android::ColorAspects::PrimariesUnspecified;
             break;
     }
 
-    MFX_OMX_AUTO_TRACE_I32(m_bitstreamColorAspects.mPrimaries);
+    MFX_OMX_AUTO_TRACE_I32(out);
 }
 
-void MfxOmxColorAspectsWrapper::MfxToOmxTransferCharacteristics(mfxU16 transferCharacteristics)
+void MfxOmxColorAspectsWrapper::MfxToOmxTransferCharacteristics(mfxU16 transferCharacteristics, android::ColorAspects::Transfer &out)
 {
     MFX_OMX_AUTO_TRACE_FUNC();
     MFX_OMX_AUTO_TRACE_I32(transferCharacteristics);
@@ -206,71 +278,71 @@ void MfxOmxColorAspectsWrapper::MfxToOmxTransferCharacteristics(mfxU16 transferC
     switch (transferCharacteristics)
     {
         case 1:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferSMPTE170M;
+            out = android::ColorAspects::TransferSMPTE170M;
             break;
 
         case 2:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferUnspecified;
+            out = android::ColorAspects::TransferUnspecified;
             break;
 
         case 4:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferGamma22;
+            out = android::ColorAspects::TransferGamma22;
             break;
 
         case 5:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferGamma28;
+            out = android::ColorAspects::TransferGamma28;
             break;
 
         case 6:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferSMPTE170M;
+            out = android::ColorAspects::TransferSMPTE170M;
             break;
 
         case 7:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferSMPTE240M;
+            out = android::ColorAspects::TransferSMPTE240M;
             break;
 
         case 8:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferLinear;
+            out = android::ColorAspects::TransferLinear;
             break;
 
         case 11:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferXvYCC;
+            out = android::ColorAspects::TransferXvYCC;
             break;
 
         case 12:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferBT1361;
+            out = android::ColorAspects::TransferBT1361;
             break;
 
         case 13:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferSRGB;
+            out = android::ColorAspects::TransferSRGB;
             break;
 
         case 14:
         case 15:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferSMPTE170M;
+            out = android::ColorAspects::TransferSMPTE170M;
             break;
 
         case 16:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferST2084;
+            out = android::ColorAspects::TransferST2084;
             break;
 
         case 17:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferST428;
+            out = android::ColorAspects::TransferST428;
             break;
 
         case 18:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferHLG;
+            out = android::ColorAspects::TransferHLG;
             break;
 
         default:
-            m_bitstreamColorAspects.mTransfer = android::ColorAspects::TransferUnspecified;
+            out = android::ColorAspects::TransferUnspecified;
             break;
     }
 
-    MFX_OMX_AUTO_TRACE_I32(m_bitstreamColorAspects.mTransfer);
+    MFX_OMX_AUTO_TRACE_I32(out);
 }
 
-void MfxOmxColorAspectsWrapper::MfxToOmxMatrixCoefficients(mfxU16 matrixCoefficients)
+void MfxOmxColorAspectsWrapper::MfxToOmxMatrixCoefficients(mfxU16 matrixCoefficients, android::ColorAspects::MatrixCoeffs &out)
 {
     MFX_OMX_AUTO_TRACE_FUNC();
     MFX_OMX_AUTO_TRACE_I32(matrixCoefficients);
@@ -278,38 +350,209 @@ void MfxOmxColorAspectsWrapper::MfxToOmxMatrixCoefficients(mfxU16 matrixCoeffici
     switch (matrixCoefficients)
     {
         case 1:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixBT709_5;
+            out = android::ColorAspects::MatrixBT709_5;
             break;
 
         case 2:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixUnspecified;
+            out = android::ColorAspects::MatrixUnspecified;
             break;
 
         case 4:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixBT470_6M;
+            out = android::ColorAspects::MatrixBT470_6M;
             break;
 
         case 5:
         case 6:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixBT601_6;
+            out = android::ColorAspects::MatrixBT601_6;
             break;
 
         case 7:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixSMPTE240M;
+            out = android::ColorAspects::MatrixSMPTE240M;
             break;
 
         case 9:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixBT2020;
+            out = android::ColorAspects::MatrixBT2020;
             break;
 
         case 10:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixBT2020Constant;
+            out = android::ColorAspects::MatrixBT2020Constant;
             break;
 
         default:
-            m_bitstreamColorAspects.mMatrixCoeffs = android::ColorAspects::MatrixUnspecified;
+            out = android::ColorAspects::MatrixUnspecified;
             break;
     }
 
-    MFX_OMX_AUTO_TRACE_I32(m_bitstreamColorAspects.mMatrixCoeffs);
+    MFX_OMX_AUTO_TRACE_I32(out);
+}
+
+void MfxOmxColorAspectsWrapper::OmxToMfxVideoRange(android::ColorAspects::Range videoRange, mfxU16 &out)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+    switch (videoRange)
+    {
+        case android::ColorAspects::RangeLimited:
+			out = 0;
+			break;
+
+        case android::ColorAspects::RangeFull:
+            out = 1;
+            break;
+
+        case android::ColorAspects::RangeUnspecified:
+            out = 0xFF;
+            break;
+
+        default:
+            // should never happen there
+            out = 0;
+            ALOGE("Unsupported video range");
+            break;
+    }
+}
+
+void MfxOmxColorAspectsWrapper::OmxToMfxColourPrimaries(android::ColorAspects::Primaries colourPrimaries, mfxU16 &out)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+    switch (colourPrimaries)
+    {
+        case android::ColorAspects::PrimariesBT709_5:
+            out = 1;
+            break;
+
+        case android::ColorAspects::PrimariesUnspecified:
+            out = 2;
+            break;
+
+        case android::ColorAspects::PrimariesBT470_6M:
+            out = 4;
+            break;
+
+        case android::ColorAspects::PrimariesBT601_6_625:
+            out = 5;
+            break;
+
+        case android::ColorAspects::PrimariesBT601_6_525:
+            out = 6;
+            break;
+
+        case android::ColorAspects::PrimariesGenericFilm:
+            out = 8;
+            break;
+
+        case android::ColorAspects::PrimariesBT2020:
+            out = 9;
+            break;
+
+        default:
+            out = 0;
+            ALOGE("Unsupported colour primaries");
+            break;
+    }
+}
+
+void MfxOmxColorAspectsWrapper::OmxToMfxTransferCharacteristics(android::ColorAspects::Transfer transferCharacteristics, mfxU16 &out)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+    switch (transferCharacteristics)
+    {
+        case android::ColorAspects::TransferSMPTE170M:
+            out = 1;
+            break;
+
+        case android::ColorAspects::TransferUnspecified:
+            out = 2;
+            break;
+
+        case android::ColorAspects::TransferGamma22:
+            out = 4;
+            break;
+
+        case android::ColorAspects::TransferGamma28:
+            out = 5;
+            break;
+
+        case android::ColorAspects::TransferSMPTE240M:
+            out = 7;
+            break;
+
+        case android::ColorAspects::TransferLinear:
+            out = 8;
+            break;
+
+        case android::ColorAspects::TransferXvYCC:
+            out = 11;
+            break;
+
+        case android::ColorAspects::TransferBT1361:
+            out = 12;
+            break;
+
+        case android::ColorAspects::TransferSRGB:
+            out = 13;
+            break;
+
+        case android::ColorAspects::TransferST2084:
+            out = 16;
+            break;
+
+        case android::ColorAspects::TransferST428:
+            out = 17;
+            break;
+
+        case android::ColorAspects::TransferHLG:
+            out = 18;
+            break;
+
+        default:
+            // should never happen there
+            out = 0;
+            ALOGE("Unsupported transfer characteristic");
+            break;
+    }
+}
+
+void MfxOmxColorAspectsWrapper::OmxToMfxMatrixCoefficients(android::ColorAspects::MatrixCoeffs matrixCoefficients, mfxU16 &out)
+{
+    MFX_OMX_AUTO_TRACE_FUNC();
+
+    switch (matrixCoefficients)
+    {
+        case android::ColorAspects::MatrixBT709_5:
+            out = 1;
+            break;
+
+        case android::ColorAspects::MatrixUnspecified:
+            out = 2;
+            break;
+
+        case android::ColorAspects::MatrixBT470_6M:
+            out = 4;
+            break;
+
+        case android::ColorAspects::MatrixBT601_6:
+            out = 5;
+            break;
+
+        case android::ColorAspects::MatrixSMPTE240M:
+            out = 7;
+            break;
+
+        case android::ColorAspects::MatrixBT2020:
+            out = 9;
+            break;
+
+        case android::ColorAspects::MatrixBT2020Constant:
+            out = 10;
+            break;
+
+        default:
+            // should never happen there
+            out = 0;
+            ALOGE("Unsupported matrix coefficients");
+            break;
+    }
 }

--- a/omx_utils/src/mfx_omx_defaults.cpp
+++ b/omx_utils/src/mfx_omx_defaults.cpp
@@ -105,7 +105,7 @@ void mfx_omx_set_defaults_mfxVideoParam_enc(mfxVideoParam* params)
         break;
     case MFX_CODEC_HEVC:
         params->mfx.CodecProfile = MFX_PROFILE_HEVC_MAIN;
-        params->mfx.CodecLevel = MFX_LEVEL_HEVC_6;
+        params->mfx.CodecLevel = MFX_LEVEL_HEVC_51;
         params->mfx.TargetUsage = MFX_TARGETUSAGE_BEST_SPEED;
         params->mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
         params->mfx.TargetKbps = 3000;

--- a/openmax/intel/OMX_IntelVideoExt.h
+++ b/openmax/intel/OMX_IntelVideoExt.h
@@ -316,6 +316,17 @@ typedef struct OMX_VIDEO_PARAM_SFC {
     OMX_U32 nOutputHeight;             // nOutputHeight is from ISV for downscaling
 } OMX_VIDEO_PARAM_SFC;
 
+// Set colour aspect info
+typedef struct OMX_VIDEO_PARAM_COLOR_ASPECT {
+    OMX_U32 nSize;
+    OMX_VERSIONTYPE nVersion;
+    OMX_U32 nPortIndex;
+    OMX_U16 nColourPrimaries;
+    OMX_U16 nVideoFullRange;
+    OMX_U16 nMatrixCoefficients;
+    OMX_U16 nTransferCharacteristics;
+} OMX_VIDEO_PARAM_COLOR_ASPECT;
+
 #define OMX_BUFFERFLAG_TFF 0x00010000
 #define OMX_BUFFERFLAG_BFF 0x00020000
 


### PR DESCRIPTION
This change contains two fixes.
1. Change HEVC encoder default level from 6 to 51.
2. Add color aspect info for video encoder

Tracked-On: OAM-95328

Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>