### PR TITLE
Disable ProfileLevel check for HEVC 10bit encoder

### DIFF
--- a/omx_components/include/components/mfx_omx_gen.h
+++ b/omx_components/include/components/mfx_omx_gen.h
@@ -68,6 +68,13 @@ static const MfxOmxProfileLevelTable g_h265_profile_levels[] =
 
 /*------------------------------------------------------------------------------*/
 
+static const MfxOmxProfileLevelTable g_h265_ve_profile_levels[] =
+{
+    { MFX_OMX_VIDEO_HEVCProfileMain, MFX_OMX_VIDEO_HEVCMainTierLevel51 }
+};
+
+/*------------------------------------------------------------------------------*/
+
 static const MfxOmxProfileLevelTable g_mp2_profile_levels[] =
 {
     { OMX_VIDEO_MPEG2ProfileSimple, OMX_VIDEO_MPEG2LevelLL },

--- a/omx_components/include/components/mfx_omx_h265ve.h
+++ b/omx_components/include/components/mfx_omx_h265ve.h
@@ -38,7 +38,7 @@ static const OMX_VIDEO_PARAM_PORTFORMATTYPE g_h265ve_output_formats[] =
     MFX_OMX_DECLARE_BST_OUTPUT_FORMAT(OMX_VIDEO_CodingHEVC)
 };
 
-#define g_h265ve_profile_levels g_h265_profile_levels
+#define g_h265ve_profile_levels g_h265_ve_profile_levels
 
 #define mfx_omx_create_h265ve_ports mfx_omx_create_port
 


### PR DESCRIPTION
This is a work around solution to disable HEVC 10bit encoder
as we don't commit HEVC 10bit encoder on CML Android R.

Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>