### PR TITLE
by pass not valid hevc bitstream

### DIFF
--- a/omx_buffers/include/mfx_omx_bst_ibuf.h
+++ b/omx_buffers/include/mfx_omx_bst_ibuf.h
@@ -84,6 +84,8 @@ public:
     virtual mfxStatus SaveHeaders(mfxBitstream *pSPS, mfxBitstream *pPPS, bool isReset) = 0;
     // detect interlaced content
     virtual bool IsSetInterlaceFlag(bool * bInterlaced) = 0;
+    // detect head include valid SPS etc
+    virtual bool IsValidHeaders(void) = 0;
 
 #ifdef ENABLE_READ_SEI
     // get saved SEI (right now only for HEVC 10 bit SeiHDRStaticInfo)
@@ -136,6 +138,11 @@ public:
     {
         *bInterlaced = false;
         return false;
+    }
+    // detect head include valid SPS etc
+    virtual bool IsValidHeaders()
+    {
+        return true;
     }
 
 #ifdef ENABLE_READ_SEI
@@ -203,6 +210,8 @@ public:
     virtual mfxStatus SaveHeaders(mfxBitstream *pSPS, mfxBitstream *pPPS, bool isReset);
     // detect interlaced content
     virtual bool IsSetInterlaceFlag(bool * bInterlaced);
+    // detect head include valid SPS etc
+    virtual bool IsValidHeaders();
 
 #ifdef ENABLE_READ_SEI
     // get saved SEI (right now only for HEVC 10 bit SeiHDRStaticInfo)

--- a/omx_buffers/src/mfx_omx_bst_ibuf.cpp
+++ b/omx_buffers/src/mfx_omx_bst_ibuf.cpp
@@ -749,6 +749,14 @@ mfxStatus MfxOmxAVCFrameConstructor::Load(mfxU8* data, mfxU32 size, mfxU64 pts, 
 
 /*------------------------------------------------------------------------------*/
 
+bool MfxOmxAVCFrameConstructor::IsValidHeaders()
+{
+    if (NULL == m_SPS.Data)
+        return false;
+
+    return true;
+}
+
 bool MfxOmxAVCFrameConstructor::IsSetInterlaceFlag(bool * bInterlaced)
 {
     MFX_OMX_AUTO_TRACE_FUNC();

--- a/omx_components/src/mfx_omx_vdec_component.cpp
+++ b/omx_components/src/mfx_omx_vdec_component.cpp
@@ -2215,6 +2215,9 @@ mfxStatus MfxOmxVdecComponent::InitCodec(void)
                 else
                     m_MfxVideoParams.mfx.FrameInfo.FourCC = MFX_FOURCC_P010;
             }
+
+            if ((MFX_CODEC_HEVC == m_MfxVideoParams.mfx.CodecId) && (!m_pOmxBitstream->GetFrameConstructor()->IsValidHeaders()))
+                mfx_res = MFX_ERR_UNSUPPORTED;
         }
         if (MFX_ERR_NONE == mfx_res)
         {


### PR DESCRIPTION
If the input HEVC bitstream didn't include valid SPS, it should
be dropped, otherwise it may trigger unknown HW issue.

Tracked-On:
Signed-off-by: Yang, Dong <dong.yang@intel.com>