### PR TITLE
Add Android 12 related build flags

### DIFF
--- a/mfx_omx_defs.mk
+++ b/mfx_omx_defs.mk
@@ -15,6 +15,9 @@
 MFX_OMX_CFLAGS := -DANDROID
 
 # Android version preference:
+ifneq ($(filter 12 12.% S ,$(PLATFORM_VERSION)),)
+  MFX_ANDROID_VERSION:= MFX_S
+endif
 ifneq ($(filter 11 11.% R ,$(PLATFORM_VERSION)),)
   MFX_ANDROID_VERSION:= MFX_R
 endif
@@ -58,7 +61,7 @@ MFX_OMX_CFLAGS += \
 
 ifeq ($(BOARD_USES_GRALLOC1),true)
   MFX_OMX_CFLAGS += -DMFX_OMX_USE_GRALLOC_1
-  ifneq ($(filter MFX_P MFX_Q MFX_R,$(MFX_ANDROID_VERSION)),)
+  ifneq ($(filter MFX_P MFX_Q MFX_R MFX_S,$(MFX_ANDROID_VERSION)),)
     # plugins should use PRIME buffer descriptor since Android P
     MFX_OMX_CFLAGS += -DMFX_OMX_USE_PRIME
   endif
@@ -91,7 +94,7 @@ ifneq ($(filter $(MFX_ANDROID_VERSION), MFX_O),)
   MFX_OMX_CFLAGS_LIBVA += -DANDROID_O
 endif
 
-ifneq ($(filter $(MFX_ANDROID_VERSION), MFX_Q MFX_R),)
+ifneq ($(filter $(MFX_ANDROID_VERSION), MFX_Q MFX_R MFX_S),)
   # HDR10 support on Android Q
   MFX_OMX_CFLAGS += -DHEVC10HDR_SUPPORT
   MFX_OMX_CFLAGS += -DENABLE_READ_SEI
@@ -110,7 +113,7 @@ MFX_OMX_INCLUDES_LIBVA := $(TARGET_OUT_HEADERS)/libva
 MFX_OMX_HEADER_LIBRARIES := libmfx_headers
 
 # Setting usual imported headers
-ifneq ($(filter MFX_O_MR1 MFX_P MFX_Q MFX_R,$(MFX_ANDROID_VERSION)),)
+ifneq ($(filter MFX_O_MR1 MFX_P MFX_Q MFX_R MFX_S,$(MFX_ANDROID_VERSION)),)
   MFX_OMX_HEADER_LIBRARIES += \
     media_plugin_headers \
     libnativebase_headers \
@@ -118,7 +121,7 @@ ifneq ($(filter MFX_O_MR1 MFX_P MFX_Q MFX_R,$(MFX_ANDROID_VERSION)),)
     libhardware_headers
 endif
 
-ifneq ($(filter MFX_P MFX_Q MFX_R,$(MFX_ANDROID_VERSION)),)
+ifneq ($(filter MFX_P MFX_Q MFX_R MFX_S,$(MFX_ANDROID_VERSION)),)
   MFX_OMX_HEADER_LIBRARIES += \
     libbase_headers
 endif


### PR DESCRIPTION
This patch adds the android 12 related build
flags for MFX

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>