### PR TITLE
Enable video post processing after hw decoding

### DIFF
--- a/mfx_omx_defs.mk
+++ b/mfx_omx_defs.mk
@@ -97,6 +97,9 @@ ifneq ($(filter $(MFX_ANDROID_VERSION), MFX_Q MFX_R),)
   MFX_OMX_CFLAGS += -DENABLE_READ_SEI
 endif
 
+# Enable vpp for decoder
+MFX_OMX_CFLAGS += -DENABLE_DECVPP
+
 # Setting usual paths to include files
 MFX_OMX_INCLUDES := $(LOCAL_PATH)/include
 

--- a/omx_components/include/mfx_omx_vdec_component.h
+++ b/omx_components/include/mfx_omx_vdec_component.h
@@ -39,6 +39,17 @@ enum MfxInitState {
     MFX_INIT_COMPLETED
 };
 
+#ifdef OMX_ENABLE_DECVPP
+#define DECODE_MAX_SRF_NUM 24
+#define VPP_MAX_SRF_NUM 10
+#define FIXED_VPP_OUTPUT
+#define SCALED_WIDTH 1920
+#define SCALED_HEIGHT 1080
+
+// round up to a multiple of 16
+#define MSDK_ALIGN16(value) (((value + 15) >> 4) << 4)
+#endif
+
 /*------------------------------------------------------------------------------*/
 
 class MfxOmxVdecComponent : public MfxOmxComponent,
@@ -161,6 +172,14 @@ protected:
     void UpdateHdrStaticInfo();
 #endif
 
+#ifdef OMX_ENABLE_DECVPP
+    mfxStatus InitVPP(void);
+    mfxStatus AllocateInternalSurfaces(void);
+    mfxStatus FreeInternalSurfaces(void);
+    mfxStatus FindOneAvailableSurface(mfxU32 &id);
+    mfxStatus ProcessFrameVpp(mfxFrameSurface1 *in_srf, mfxFrameSurface1 *out_srf);
+#endif
+
 protected:
     mfxIMPL m_Implementation;
     MFXVideoSession m_Session;
@@ -188,6 +207,18 @@ protected:
     bool m_bAllocateNativeHandle;
     bool m_bEnableNativeBuffersReceived;
     bool m_bInterlaced;
+
+#ifdef OMX_ENABLE_DECVPP
+    MFXVideoVPP *m_pVPP;
+    bool m_bInitVPP;
+    bool m_bVPPDetermined;
+    bool m_bEnableScale;
+    mfxU32 m_nScaledWidth;
+    mfxU32 m_nScaledHeight;
+    mfxVideoParam m_vppParam;
+    mfxFrameSurface1 m_DecInterSrf[DECODE_MAX_SRF_NUM];
+    mfxFrameAllocResponse m_DecResponses;
+#endif
 
     MfxInitState m_InitState;
     MfxOmxDev* m_pDevice;

--- a/omx_utils/include/mfx_omx_allocator.h
+++ b/omx_utils/include/mfx_omx_allocator.h
@@ -56,6 +56,9 @@ protected: //functions
 
 protected: // variables
     MfxOmxFrameAllocResponse m_DecoderResponse;
+#ifdef OMX_ENABLE_DECVPP
+    MfxOmxFrameAllocResponse m_VPPResponse;
+#endif
 
 private:
     MFX_OMX_CLASS_NO_COPY(MfxOmxFrameAllocator)

--- a/omx_utils/include/mfx_omx_defs.h
+++ b/omx_utils/include/mfx_omx_defs.h
@@ -65,6 +65,10 @@
     #include <ufo/graphics.h>
 #endif
 
+#ifdef ENABLE_DECVPP
+    #define OMX_ENABLE_DECVPP
+#endif
+
 #include <media/hardware/MetadataBufferType.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This change is to enable video post processing after
hw decoding. The final output is 2X scaling of input.

Tracked-On:
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>