### PR TITLE
Support SKU3 and SKU4 GPU media omx

### DIFF
--- a/omx_utils/src/mfx_omx_dev_android.cpp
+++ b/omx_utils/src/mfx_omx_dev_android.cpp
@@ -55,6 +55,7 @@ const mfx_device_item listLegalDevIDs[] = {
     { 0x4551, MFX_HW_EHL},
     { 0x4569, MFX_HW_EHL},
     { 0x4571, MFX_HW_EHL},
+    { 0x4555, MFX_HW_EHL},
     /* BXT */
     { 0x0A84, MFX_HW_BXT},
     { 0x0A85, MFX_HW_BXT},


### PR DESCRIPTION
Support SKU3 and SKU4 GPU media omx

    Add support for GPU id 0x4555 as present in EHL SKU 3/3A/4 B1 variant

    Tracked-On: OAM-100773
    Signed-off-by: Kant, Rohit <rohitx.kant@intel.com>
